### PR TITLE
yahooAPIが有料API用のURLに変更になりました

### DIFF
--- a/lib/Lingua/JA/Expand/DataSource/YahooSearch.pm
+++ b/lib/Lingua/JA/Expand/DataSource/YahooSearch.pm
@@ -60,7 +60,7 @@ sub _prepare {
     }
     $self->{user_agent} = LWP::UserAgent->new(%LWP_UserAgent_config);
     my $yahoo_api_appid = $self->config->{yahoo_api_appid};
-    croak("you must set your own 'yahoo_api_app_id'") if !$yahoo_api_appid;
+    croak("you must set your own 'yahoo_api_appid'") if !$yahoo_api_appid;
     $self->{url}
         = 'http://search.yahooapis.jp/WebSearchServicePro/V1/webSearch?appid='
         . $yahoo_api_appid

--- a/lib/Lingua/JA/Expand/DataSource/YahooSearch.pm
+++ b/lib/Lingua/JA/Expand/DataSource/YahooSearch.pm
@@ -62,7 +62,7 @@ sub _prepare {
     my $yahoo_api_appid = $self->config->{yahoo_api_appid};
     croak("you must set your own 'yahoo_api_app_id'") if !$yahoo_api_appid;
     $self->{url}
-        = 'http://search.yahooapis.jp/WebSearchService/V2/webSearch?appid='
+        = 'http://search.yahooapis.jp/WebSearchServicePro/V1/webSearch?appid='
         . $yahoo_api_appid
         . '&results=20&adult_ok=1&query=';
 }


### PR DESCRIPTION
非常に便利なモジュールありがとうございます。

http://developer.yahoo.co.jp/webapi/search/websearchpro/v1/websearch.html

> 当APIは2013年1月23日にリリースされた有料版ウェブ検索APIです。
> 従来のウェブ検索APIは2013年3月31日をもちまして提供を停止致しました。

との事ですのでAPI用のURLを変更しました。

[検索:ウェブ検索API - Yahoo!デベロッパーネットワーク](http://developer.yahoo.co.jp/webapi/search/websearchpro/v1/websearch.html)
